### PR TITLE
Add support for storing log files in specified path in bucket

### DIFF
--- a/Nuget/package.nuspec
+++ b/Nuget/package.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>HaemmerElectronics.SeppPenner.Serilog.Sinks.AmazonS3</id>
-    <version>1.0.4.0</version>
+    <version>1.0.5.0</version>
     <authors>SeppPenner</authors>
     <owners>SeppPenner</owners>
     <projectUrl>https://github.com/SeppPenner/Serilog.Sinks.AmazonS3/</projectUrl>
@@ -21,7 +21,7 @@
 	  so thanks to all the https://github.com/serilog/serilog-sinks-file/graphs/contributors of this project :thumbsup:.
 	</description>
     <releaseNotes>
-	  Version 1.0.4.0 (2019-11-12): Small updates, added new option "autoUploadEvents" to the sink.
+	  Version 1.0.5.0 (2019-12-05): Added new option "bucketPath" to the sink.
 	</releaseNotes>
     <copyright>Copyright © Hämmer Electronics</copyright>
     <tags>c# csharp serilog amazon s3 amazons3 sink logging log</tags>

--- a/Serilog.Sinks.AmazonS3/Serilog.Sinks.AmazonS3/LoggerConfigurationAmazonS3Extensions.cs
+++ b/Serilog.Sinks.AmazonS3/Serilog.Sinks.AmazonS3/LoggerConfigurationAmazonS3Extensions.cs
@@ -117,6 +117,7 @@ namespace Serilog
         ///     events.
         /// </param>
         /// <param name="failureCallback">          (Optional) The failure callback. </param>
+        /// <param name="bucketPath">               (Optional) The Amazon S3 bucket path. </param>
         /// <returns>   Configuration object allowing method chaining. </returns>
         public static LoggerConfiguration AmazonS3(
             this LoggerSinkConfiguration sinkConfiguration,
@@ -136,7 +137,8 @@ namespace Serilog
             int? retainedFileCountLimit = DefaultRetainedFileCountLimit,
             Encoding encoding = null,
             FileLifecycleHooks hooks = null,
-            Action<Exception> failureCallback = null)
+            Action<Exception> failureCallback = null,
+            string bucketPath = null)
         {
             if (sinkConfiguration == null)
             {
@@ -195,7 +197,8 @@ namespace Serilog
                     awsAccessKeyId,
                     awsSecretAccessKey,
                     autoUploadEvents,
-                    failureCallback),
+                    failureCallback,
+                    bucketPath),
                 restrictedToMinimumLevel,
                 levelSwitch);
         }
@@ -275,6 +278,7 @@ namespace Serilog
         ///     events.
         /// </param>
         /// <param name="failureCallback">          (Optional) The failure callback. </param>
+        /// <param name="bucketPath">               (Optional) The Amazon S3 bucket path. </param>
         /// <returns>   Configuration object allowing method chaining. </returns>
         public static LoggerConfiguration AmazonS3(
             this LoggerSinkConfiguration sinkConfiguration,
@@ -292,7 +296,8 @@ namespace Serilog
             int? retainedFileCountLimit = DefaultRetainedFileCountLimit,
             Encoding encoding = null,
             FileLifecycleHooks hooks = null,
-            Action<Exception> failureCallback = null)
+            Action<Exception> failureCallback = null,
+            string bucketPath = null)
         {
             if (sinkConfiguration == null)
             {
@@ -339,7 +344,8 @@ namespace Serilog
                     bucketName,
                     endpoint,
                     autoUploadEvents,
-                    failureCallback),
+                    failureCallback,
+                    bucketPath),
                 restrictedToMinimumLevel,
                 levelSwitch);
         }

--- a/Serilog.Sinks.AmazonS3/Serilog.Sinks.AmazonS3/Serilog.Sinks.AmazonS3.csproj
+++ b/Serilog.Sinks.AmazonS3/Serilog.Sinks.AmazonS3/Serilog.Sinks.AmazonS3.csproj
@@ -10,9 +10,9 @@
     <PackageProjectUrl>https://www.nuget.org/packages/HaemmerElectronics.SeppPenner.Serilog.Sinks.AmazonS3/</PackageProjectUrl>
     <RepositoryUrl>https://github.com/SeppPenner/Serilog.Sinks.AmazonS3</RepositoryUrl>
     <PackageLicenseUrl>https://github.com/SeppPenner/https://github.com/SeppPenner/Serilog.Sinks.AmazonS3/blob/master/License.txt</PackageLicenseUrl>
-    <AssemblyVersion>1.0.2.0</AssemblyVersion>
-    <FileVersion>1.0.2.0</FileVersion>
-    <Version>1.0.2</Version>
+    <AssemblyVersion>1.0.5.0</AssemblyVersion>
+    <FileVersion>1.0.5.0</FileVersion>
+    <Version>1.0.5</Version>
     <PackageTags>c# csharp serilog amazon s3 amazons3 sink logging log</PackageTags>
     <PackageReleaseNotes>Added icon to the nuget package.</PackageReleaseNotes>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/Serilog.Sinks.AmazonS3/Serilog.Sinks.AmazonS3/Sinks/AmazonS3/AmazonS3Sink.cs
+++ b/Serilog.Sinks.AmazonS3/Serilog.Sinks.AmazonS3/Sinks/AmazonS3/AmazonS3Sink.cs
@@ -51,6 +51,7 @@ namespace Serilog.Sinks.AmazonS3
         /// <param name="awsSecretAccessKey">       The Amazon S3 secret access key. </param>
         /// <param name="autoUploadEvents">         Automatically upload all events immediately. </param>
         /// <param name="failureCallback">          (Optional) The failure callback. </param>
+        /// <param name="bucketPath">               (Optional) The Amazon S3 bucket path. </param>
         public AmazonS3Sink(
             ITextFormatter formatter,
             string path,
@@ -65,7 +66,8 @@ namespace Serilog.Sinks.AmazonS3
             string awsAccessKeyId,
             string awsSecretAccessKey,
             bool autoUploadEvents,
-            Action<Exception> failureCallback = null)
+            Action<Exception> failureCallback = null,
+            string bucketPath = null)
         {
             if (string.IsNullOrWhiteSpace(path))
             {
@@ -113,7 +115,8 @@ namespace Serilog.Sinks.AmazonS3
                 awsAccessKeyId,
                 awsSecretAccessKey,
                 autoUploadEvents,
-                failureCallback);
+                failureCallback,
+                bucketPath);
         }
 
         /// <summary>   Initializes a new instance of the <see cref="AmazonS3Sink" /> class. </summary>
@@ -139,6 +142,7 @@ namespace Serilog.Sinks.AmazonS3
         /// <param name="endpoint">                 The Amazon S3 endpoint. </param>
         /// <param name="autoUploadEvents">         Automatically upload all events immediately. </param>
         /// <param name="failureCallback">          (Optional) The failure callback. </param>
+        /// <param name="bucketPath">               (Optional) The Amazon S3 bucket path. </param>
         public AmazonS3Sink(
             ITextFormatter formatter,
             string path,
@@ -151,7 +155,8 @@ namespace Serilog.Sinks.AmazonS3
             string bucketName,
             RegionEndpoint endpoint,
             bool autoUploadEvents,
-            Action<Exception> failureCallback = null)
+            Action<Exception> failureCallback = null,
+            string bucketPath = null)
         {
             if (string.IsNullOrWhiteSpace(path))
             {
@@ -187,7 +192,8 @@ namespace Serilog.Sinks.AmazonS3
                 bucketName,
                 endpoint,
                 autoUploadEvents,
-                failureCallback);
+                failureCallback,
+                bucketPath);
         }
 
         /// <summary>   Emit the provided log event to the sink. </summary>

--- a/Serilog.Sinks.AmazonS3/Serilog.Sinks.AmazonS3/Sinks/AmazonS3/PathRoller.cs
+++ b/Serilog.Sinks.AmazonS3/Serilog.Sinks.AmazonS3/Sinks/AmazonS3/PathRoller.cs
@@ -57,6 +57,7 @@ namespace Serilog.Sinks.AmazonS3
             this.periodFormat = interval.GetFormat();
 
             var pathDirectory = Path.GetDirectoryName(path);
+            this.LogFileBucketPath = pathDirectory;
             if (string.IsNullOrEmpty(pathDirectory))
             {
                 pathDirectory = Directory.GetCurrentDirectory();
@@ -82,6 +83,10 @@ namespace Serilog.Sinks.AmazonS3
         /// <value> The log file directory. </value>
 
         public string LogFileDirectory { get; }
+
+        /// <summary>   Gets the bucket log file path. </summary>
+        /// <value> The log file bucket path. </value>
+        public string LogFileBucketPath { get; }
 
         /// <summary>   Gets the current checkpoint. </summary>
         /// <param name="instant">  The instant. </param>

--- a/Serilog.Sinks.AmazonS3/Serilog.Sinks.AmazonS3/Sinks/AmazonS3/PathRoller.cs
+++ b/Serilog.Sinks.AmazonS3/Serilog.Sinks.AmazonS3/Sinks/AmazonS3/PathRoller.cs
@@ -44,9 +44,10 @@ namespace Serilog.Sinks.AmazonS3
         ///     An <see cref="ArgumentNullException" /> thrown
         ///     when the path is null.
         /// </exception>
-        /// <param name="path">     The path. </param>
-        /// <param name="interval"> The interval. </param>
-        public PathRoller(string path, RollingInterval interval)
+        /// <param name="path">         The path. </param>
+        /// <param name="interval">     The interval. </param>
+        /// <param name="bucketPath">   The Amazon S3 bucket path. </param>
+        public PathRoller(string path, RollingInterval interval, string bucketPath = null)
         {
             if (path == null)
             {
@@ -57,13 +58,13 @@ namespace Serilog.Sinks.AmazonS3
             this.periodFormat = interval.GetFormat();
 
             var pathDirectory = Path.GetDirectoryName(path);
-            this.LogFileBucketPath = pathDirectory;
             if (string.IsNullOrEmpty(pathDirectory))
             {
                 pathDirectory = Directory.GetCurrentDirectory();
             }
 
             this.LogFileDirectory = Path.GetFullPath(pathDirectory);
+            this.LogFileBucketPath = bucketPath;
             this.filenamePrefix = Path.GetFileNameWithoutExtension(path);
             this.filenameSuffix = Path.GetExtension(path);
             this.filenameMatcher = new Regex(

--- a/Serilog.Sinks.AmazonS3/Serilog.Sinks.AmazonS3/Sinks/AmazonS3/RollingFileSink.cs
+++ b/Serilog.Sinks.AmazonS3/Serilog.Sinks.AmazonS3/Sinks/AmazonS3/RollingFileSink.cs
@@ -87,6 +87,9 @@ namespace Serilog.Sinks.AmazonS3
         /// <summary>   The next checkpoint. </summary>
         private DateTime? nextCheckpoint;
 
+        /// <summary>   The path where local files are stored. </summary>
+        private readonly string bucketPath;
+
         /// <summary>   Initializes a new instance of the <see cref="RollingFileSink" /> class. </summary>
         /// <exception cref="ArgumentNullException">
         ///     An <see cref="ArgumentNullException" /> thrown
@@ -112,6 +115,7 @@ namespace Serilog.Sinks.AmazonS3
         /// <param name="awsSecretAccessKey">       The Amazon S3 access key. </param>
         /// <param name="autoUploadEvents">         Automatically upload all events immediately. </param>
         /// <param name="failureCallback">          (Optional) The failure callback. </param>
+        /// <param name="bucketPath">               (Optional) The Amazon S3 bucket path. </param>
         public RollingFileSink(
             string path,
             ITextFormatter textFormatter,
@@ -127,7 +131,8 @@ namespace Serilog.Sinks.AmazonS3
             string awsAccessKeyId,
             string awsSecretAccessKey,
             bool autoUploadEvents,
-            Action<Exception> failureCallback = null)
+            Action<Exception> failureCallback = null,
+            string bucketPath = null)
         {
             if (string.IsNullOrWhiteSpace(path))
             {
@@ -169,7 +174,7 @@ namespace Serilog.Sinks.AmazonS3
             this.awsAccessKeyId = awsAccessKeyId;
             this.awsSecretAccessKey = awsSecretAccessKey;
             this.endpoint = endpoint;
-            this.pathRoller = new PathRoller(path, rollingInterval);
+            this.pathRoller = new PathRoller(path, rollingInterval, bucketPath);
             this.textFormatter = textFormatter;
             this.fileSizeLimitBytes = fileSizeLimitBytes;
             this.retainedFileCountLimit = retainedFileCountLimit;
@@ -178,6 +183,7 @@ namespace Serilog.Sinks.AmazonS3
             this.rollOnFileSizeLimit = rollOnFileSizeLimit;
             this.fileLifecycleHooks = fileLifecycleHooks;
             this.autoUploadEvents = autoUploadEvents;
+            this.bucketPath = bucketPath;
         }
 
         /// <summary>   Initializes a new instance of the <see cref="RollingFileSink" /> class. </summary>
@@ -203,6 +209,7 @@ namespace Serilog.Sinks.AmazonS3
         /// <param name="endpoint">                 The Amazon S3 endpoint. </param>
         /// <param name="autoUploadEvents">         Automatically upload all events immediately. </param>
         /// <param name="failureCallback">          (Optional) The failure callback. </param>
+        /// <param name="bucketPath">               (Optional) The Amazon S3 bucket path. </param>
         public RollingFileSink(
             string path,
             ITextFormatter textFormatter,
@@ -216,7 +223,8 @@ namespace Serilog.Sinks.AmazonS3
             string bucketName,
             RegionEndpoint endpoint,
             bool autoUploadEvents,
-            Action<Exception> failureCallback = null)
+            Action<Exception> failureCallback = null,
+            string bucketPath = null)
         {
             if (string.IsNullOrWhiteSpace(path))
             {
@@ -246,7 +254,7 @@ namespace Serilog.Sinks.AmazonS3
 
             this.bucketName = bucketName;
             this.endpoint = endpoint;
-            this.pathRoller = new PathRoller(path, rollingInterval);
+            this.pathRoller = new PathRoller(path, rollingInterval, bucketPath);
             this.textFormatter = textFormatter;
             this.fileSizeLimitBytes = fileSizeLimitBytes;
             this.retainedFileCountLimit = retainedFileCountLimit;
@@ -255,6 +263,7 @@ namespace Serilog.Sinks.AmazonS3
             this.rollOnFileSizeLimit = rollOnFileSizeLimit;
             this.fileLifecycleHooks = fileLifecycleHooks;
             this.autoUploadEvents = autoUploadEvents;
+            this.bucketPath = bucketPath;
         }
 
         /// <summary>

--- a/Serilog.Sinks.AmazonS3/Serilog.Sinks.AmazonS3/Sinks/AmazonS3/RollingFileSink.cs
+++ b/Serilog.Sinks.AmazonS3/Serilog.Sinks.AmazonS3/Sinks/AmazonS3/RollingFileSink.cs
@@ -566,7 +566,8 @@ namespace Serilog.Sinks.AmazonS3
                     var putRequest = new PutObjectRequest()
                     {
                         BucketName = this.bucketName,
-                        Key = Path.GetFileName(this.currentFileName),
+                        Key = Path.Combine(this.pathRoller.LogFileBucketPath, Path.GetFileName(this.currentFileName))
+                            .Replace("\\", "/"),
                         InputStream = fs
                     };
                     return await client.PutObjectAsync(putRequest);


### PR DESCRIPTION
I'm missing possibility to store log files in specified path not only on root folder.
With this tweak you can pass "path" attribute as "my/container/log.txt" and log files will be saved in  "my/container/*" instead bucket root folder.