### PR TITLE
Add new constructor taking serviceUrl instead of Endpoint

### DIFF
--- a/src/Serilog.Sinks.AmazonS3/LoggerConfigurationAmazonS3Extensions.cs
+++ b/src/Serilog.Sinks.AmazonS3/LoggerConfigurationAmazonS3Extensions.cs
@@ -214,6 +214,169 @@ namespace Serilog
         ///     unsupported or illegal values.
         /// </exception>
         /// <param name="sinkConfiguration">        Logger sink configuration. </param>
+        /// <param name="path">                     Path to the file. </param>
+        /// <param name="bucketName">               The Amazon S3 bucket name. </param>
+        /// <param name="serviceUrl">               The Amazon S3 service url. </param>
+        /// <param name="awsAccessKeyId">           The Amazon S3 access key id. </param>
+        /// <param name="awsSecretAccessKey">       The Amazon S3 access key. </param>
+        /// <param name="autoUploadEvents">         Automatically upload all events immediately. </param>
+        /// <param name="restrictedToMinimumLevel">
+        ///     (Optional)
+        ///     The minimum level for
+        ///     events passed through the sink. Ignored when
+        ///     <paramref name="levelSwitch" /> is specified.
+        /// </param>
+        /// <param name="outputTemplate">
+        ///     (Optional)
+        ///     A message template describing the format used to
+        ///     write to the sink.
+        ///     the default is "{Timestamp:yyyy-MM-dd
+        ///     HH:mm:ss.fff zzz} [{Level:u3}]
+        ///     {Message:lj}{NewLine}{Exception}".
+        /// </param>
+        /// <param name="formatProvider">
+        ///     (Optional)
+        ///     Supplies culture-specific formatting information, or
+        ///     null.
+        /// </param>
+        /// <param name="fileSizeLimitBytes">
+        ///     (Optional)
+        ///     The approximate maximum size, in bytes, to which a
+        ///     log file will be allowed to grow.
+        ///     For unrestricted growth, pass null. The default
+        ///     is 1 GB. To avoid writing partial events, the
+        ///     last event within the limit will be written in
+        ///     full even if it exceeds the limit.
+        /// </param>
+        /// <param name="levelSwitch">
+        ///     (Optional)
+        ///     A switch allowing the pass-through minimum level
+        ///     to be changed at runtime.
+        /// </param>
+        /// <param name="buffered">
+        ///     (Optional)
+        ///     Indicates if flushing to the output file can be
+        ///     buffered or not. The default
+        ///     is false.
+        /// </param>
+        /// <param name="rollingInterval">
+        ///     (Optional)
+        ///     The interval at which logging will roll over to a new
+        ///     file.
+        /// </param>
+        /// <param name="retainedFileCountLimit">
+        ///     (Optional)
+        ///     The maximum number of log files that will be retained,
+        ///     including the current log file. For unlimited
+        ///     retention, pass null. The default is 31.
+        /// </param>
+        /// <param name="encoding">
+        ///     (Optional)
+        ///     Character encoding used to write the text file. The
+        ///     default is UTF-8 without BOM.
+        /// </param>
+        /// <param name="hooks">
+        ///     (Optional)
+        ///     Optionally enables hooking into log file lifecycle
+        ///     events.
+        /// </param>
+        /// <param name="failureCallback">          (Optional) The failure callback. </param>
+        /// <param name="bucketPath">               (Optional) The Amazon S3 bucket path. </param>
+        /// <returns>   Configuration object allowing method chaining. </returns>
+        public static LoggerConfiguration AmazonS3(
+            this LoggerSinkConfiguration sinkConfiguration,
+            string path,
+            string bucketName,
+            string serviceUrl,
+            string awsAccessKeyId,
+            string awsSecretAccessKey,
+            bool autoUploadEvents = false,
+            LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
+            string outputTemplate = DefaultOutputTemplate,
+            IFormatProvider formatProvider = null,
+            long? fileSizeLimitBytes = DefaultFileSizeLimitBytes,
+            LoggingLevelSwitch levelSwitch = null,
+            bool buffered = false,
+            RollingInterval rollingInterval = RollingInterval.Day,
+            int? retainedFileCountLimit = DefaultRetainedFileCountLimit,
+            Encoding encoding = null,
+            FileLifecycleHooks hooks = null,
+            Action<Exception> failureCallback = null,
+            string bucketPath = null)
+        {
+            if (sinkConfiguration == null)
+            {
+                throw new ArgumentNullException(nameof(sinkConfiguration));
+            }
+
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                throw new ArgumentNullException(nameof(path));
+            }
+
+            if (string.IsNullOrWhiteSpace(bucketName))
+            {
+                throw new ArgumentNullException(nameof(bucketName));
+            }
+
+            if (serviceUrl == null)
+            {
+                throw new ArgumentNullException(nameof(serviceUrl));
+            }
+
+            if (string.IsNullOrWhiteSpace(awsAccessKeyId))
+            {
+                throw new ArgumentNullException(nameof(awsAccessKeyId));
+            }
+
+            if (string.IsNullOrWhiteSpace(awsSecretAccessKey))
+            {
+                throw new ArgumentNullException(nameof(awsSecretAccessKey));
+            }
+
+            if (retainedFileCountLimit.HasValue && retainedFileCountLimit < 1)
+            {
+                throw new ArgumentException(
+                    "Zero or negative value provided; retained file count limit must be at least 1.");
+            }
+
+            if (outputTemplate == null)
+            {
+                throw new ArgumentNullException(nameof(outputTemplate));
+            }
+
+            var formatter = new MessageTemplateTextFormatter(outputTemplate, formatProvider);
+            return sinkConfiguration.Sink(
+                new AmazonS3Sink(
+                    formatter,
+                    path,
+                    fileSizeLimitBytes,
+                    buffered,
+                    encoding,
+                    rollingInterval,
+                    retainedFileCountLimit,
+                    hooks,
+                    bucketName,
+                    serviceUrl,
+                    awsAccessKeyId,
+                    awsSecretAccessKey,
+                    autoUploadEvents,
+                    failureCallback,
+                    bucketPath),
+                restrictedToMinimumLevel,
+                levelSwitch);
+        }
+
+        /// <summary>   Write log events to the specified file. </summary>
+        /// <exception cref="ArgumentNullException">
+        ///     Thrown when one or more required arguments are
+        ///     null.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///     Thrown when one or more arguments have
+        ///     unsupported or illegal values.
+        /// </exception>
+        /// <param name="sinkConfiguration">        Logger sink configuration. </param>
         /// <param name="formatter">                The formatter.</param>
         /// <param name="path">                     Path to the file. </param>
         /// <param name="bucketName">               The Amazon S3 bucket name. </param>

--- a/src/Serilog.Sinks.AmazonS3/Sinks/AmazonS3/AmazonS3Sink.cs
+++ b/src/Serilog.Sinks.AmazonS3/Sinks/AmazonS3/AmazonS3Sink.cs
@@ -139,6 +139,99 @@ namespace Serilog.Sinks.AmazonS3
         /// <param name="retainedFileCountLimit">   The retained file count limit. </param>
         /// <param name="hooks">                    The hooks. </param>
         /// <param name="bucketName">               The Amazon S3 bucket name. </param>
+        /// <param name="serviceUrl">               The Amazon S3 service url. </param>
+        /// <param name="awsAccessKeyId">           The Amazon S3 access key id. </param>
+        /// <param name="awsSecretAccessKey">       The Amazon S3 secret access key. </param>
+        /// <param name="autoUploadEvents">         Automatically upload all events immediately. </param>
+        /// <param name="failureCallback">          (Optional) The failure callback. </param>
+        /// <param name="bucketPath">               (Optional) The Amazon S3 bucket path. </param>
+        public AmazonS3Sink(
+            ITextFormatter formatter,
+            string path,
+            long? fileSizeLimitBytes,
+            bool buffered,
+            Encoding encoding,
+            RollingInterval rollingInterval,
+            int? retainedFileCountLimit,
+            FileLifecycleHooks hooks,
+            string bucketName,
+            string serviceUrl,
+            string awsAccessKeyId,
+            string awsSecretAccessKey,
+            bool autoUploadEvents,
+            Action<Exception> failureCallback = null,
+            string bucketPath = null)
+        {
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                throw new ArgumentNullException(nameof(path));
+            }
+
+            if (string.IsNullOrWhiteSpace(bucketName))
+            {
+                throw new ArgumentNullException(nameof(bucketName));
+            }
+
+            if (string.IsNullOrWhiteSpace(awsAccessKeyId))
+            {
+                throw new ArgumentNullException(nameof(awsAccessKeyId));
+            }
+
+            if (string.IsNullOrWhiteSpace(awsSecretAccessKey))
+            {
+                throw new ArgumentNullException(nameof(awsSecretAccessKey));
+            }
+
+            if (fileSizeLimitBytes.HasValue && fileSizeLimitBytes < 0)
+            {
+                throw new ArgumentException("Negative value provided; file size limit must be non-negative.");
+            }
+
+            if (retainedFileCountLimit.HasValue && retainedFileCountLimit < 1)
+            {
+                throw new ArgumentException(
+                    "Zero or negative value provided; retained file count limit must be at least 1.");
+            }
+
+            this.sink = new RollingFileSink(
+                path,
+                formatter,
+                fileSizeLimitBytes,
+                retainedFileCountLimit,
+                encoding,
+                buffered,
+                rollingInterval,
+                true,
+                hooks,
+                bucketName,
+                serviceUrl,
+                awsAccessKeyId,
+                awsSecretAccessKey,
+                autoUploadEvents,
+                failureCallback,
+                bucketPath);
+        }
+
+        /// <summary>   Initializes a new instance of the <see cref="AmazonS3Sink" /> class. </summary>
+        /// <exception cref="ArgumentNullException">    addSink or formatter or path. </exception>
+        /// <exception cref="ArgumentException">
+        ///     Negative value provided; file size limit must be
+        ///     non-negative. - fileSizeLimitBytes or At least one
+        ///     file must be retained. - retainedFileCountLimit or
+        ///     Buffered writes are not available when file sharing
+        ///     is enabled. - buffered or File lifecycle hooks are
+        ///     not currently supported for shared log files. -
+        ///     hooks.
+        /// </exception>
+        /// <param name="formatter">                The formatter. </param>
+        /// <param name="path">                     The path. </param>
+        /// <param name="fileSizeLimitBytes">       The file size limit bytes. </param>
+        /// <param name="buffered">                 if set to <c>true</c> [buffered]. </param>
+        /// <param name="encoding">                 The encoding. </param>
+        /// <param name="rollingInterval">          The rolling interval. </param>
+        /// <param name="retainedFileCountLimit">   The retained file count limit. </param>
+        /// <param name="hooks">                    The hooks. </param>
+        /// <param name="bucketName">               The Amazon S3 bucket name. </param>
         /// <param name="endpoint">                 The Amazon S3 endpoint. </param>
         /// <param name="autoUploadEvents">         Automatically upload all events immediately. </param>
         /// <param name="failureCallback">          (Optional) The failure callback. </param>


### PR DESCRIPTION
For enterprise usage it should be possible to specify service url instead of endpoint
This pull request adds a constructor taking the service url in parameter.