### PR TITLE
Apply AmazonS3Client properly in AmazonS3Options

### DIFF
--- a/src/Serilog.Sinks.AmazonS3/Sinks/AmazonS3/AmazonS3Sink.cs
+++ b/src/Serilog.Sinks.AmazonS3/Sinks/AmazonS3/AmazonS3Sink.cs
@@ -40,6 +40,7 @@ namespace Serilog.Sinks.AmazonS3
         /// <param name="amazonS3Options">The Amazon S3 options.</param>
         public AmazonS3Sink(AmazonS3Options amazonS3Options)
         {
+            this.amazonS3Options.AmazonS3Client = amazonS3Options.AmazonS3Client;
             this.amazonS3Options.Path = amazonS3Options.Path;
             this.amazonS3Options.BucketName = amazonS3Options.BucketName;
             this.amazonS3Options.Endpoint = amazonS3Options.Endpoint;


### PR DESCRIPTION
This PR assigns `AmazonS3Client` to `AmazonS3Sink.amazonS3Options` properly to fix invalid URI errors when using `.WriteTo.AmazonS3()` using `AmazonS3Client` directly.

