### PR TITLE
storing service url from provided settings in sink

### DIFF
--- a/src/Serilog.Sinks.AmazonS3/Sinks/AmazonS3/AmazonS3Sink.cs
+++ b/src/Serilog.Sinks.AmazonS3/Sinks/AmazonS3/AmazonS3Sink.cs
@@ -61,6 +61,7 @@ namespace Serilog.Sinks.AmazonS3
             this.amazonS3Options.Encoding = amazonS3Options.Encoding;
             this.amazonS3Options.FailureCallback = amazonS3Options.FailureCallback;
             this.amazonS3Options.BucketPath = amazonS3Options.BucketPath;
+            this.amazonS3Options.ServiceURL = amazonS3Options.ServiceURL;
         }
 
         /// <summary>Emit a batch of log events, running asynchronously.</summary>


### PR DESCRIPTION
service url is never set in sink constructor

digital ocean spaces is S3 compatible, without this change spaces cannot be used in place of S3