### PR TITLE
Fixing ServiceUrl to include protocol

### DIFF
--- a/HowToUse.md
+++ b/HowToUse.md
@@ -92,7 +92,7 @@ The project can be found on [nuget](https://www.nuget.org/packages/Serilog.Sinks
 |path|The main log file name used.|`"log.txt"`|None, is mandatory.|
 |bucketName|The name of the Amazon S3 bucket to use. Check: https://docs.aws.amazon.com/general/latest/gr/rande.html.|`"mytestbucket-aws"`|None, is mandatory.|
 |endpoint|The Amazon S3 endpoint location.|`RegionEndpoint.EUWest2`|None, is mandatory. (Either `endpoint` or `serviceUrl` needs to be set.)|
-|serviceUrl|The Amazon S3 service URL.|`s3.amazonaws.com`|Default is `s3.amazonaws.com`. (Either `endpoint` or `serviceUrl` needs to be set.)|
+|serviceUrl|The Amazon S3 service URL. Check https://docs.aws.amazon.com/general/latest/gr/s3.html.|`https://s3.amazonaws.com`|Default is `https://s3.amazonaws.com`. (Either `endpoint` or `serviceUrl` needs to be set.)|
 |awsAccessKeyId|The Amazon S3 access key id.|`ABCDEFGHIJKLMNOP`|None, is mandatory. (Not required if you are using role based authentication).|
 |awsSecretAccessKey|The Amazon S3 secret access key.|`c3fghsrgwegfn://asdfsdfsdgfsdg`|None, is mandatory. (Not required if you are using role based authentication).|
 |restrictedToMinimumLevel|The minimum level for events passed through the sink. Ignored when `levelSwitch` is specified. Check: https://github.com/serilog/serilog/blob/dev/src/Serilog/Events/LogEventLevel.cs.|`LogEventLevel.Information`|`LogEventLevel.Verbose`|

--- a/src/Serilog.Sinks.AmazonS3/ErrorMessageConstants.cs
+++ b/src/Serilog.Sinks.AmazonS3/ErrorMessageConstants.cs
@@ -1,0 +1,15 @@
+﻿using Serilog.Sinks.AmazonS3;
+
+namespace Serilog
+{
+    /// <summary>
+    /// Constants to use in user-facing error messages.
+    /// </summary>
+    internal static class ErrorMessageConstants
+    {
+        /// <summary>
+        /// <see cref="AmazonS3Options.ServiceUrl"/> provided is in invalid format.
+        /// </summary>
+        internal const string ServiceUrlInvalidFormat = "URL must be valid absolute URL including protocol.";
+    }
+}

--- a/src/Serilog.Sinks.AmazonS3/LoggerConfigurationAmazonS3Extensions.cs
+++ b/src/Serilog.Sinks.AmazonS3/LoggerConfigurationAmazonS3Extensions.cs
@@ -639,6 +639,11 @@ namespace Serilog
                 throw new ArgumentNullException(nameof(serviceUrl));
             }
 
+            if (!S3ConfigurationValidator.ValidateServiceUrl(serviceUrl))
+            {
+                throw new ArgumentException(ErrorMessageConstants.ServiceUrlInvalidFormat, nameof(serviceUrl));
+            }
+
             if (string.IsNullOrWhiteSpace(awsAccessKeyId))
             {
                 throw new ArgumentNullException(nameof(awsAccessKeyId));
@@ -763,6 +768,11 @@ namespace Serilog
             if (string.IsNullOrWhiteSpace(serviceUrl))
             {
                 throw new ArgumentNullException(nameof(serviceUrl));
+            }
+
+            if (!S3ConfigurationValidator.ValidateServiceUrl(serviceUrl))
+            {
+                throw new ArgumentException(ErrorMessageConstants.ServiceUrlInvalidFormat, nameof(serviceUrl));
             }
 
             if (string.IsNullOrWhiteSpace(awsAccessKeyId))
@@ -899,6 +909,11 @@ namespace Serilog
                 throw new ArgumentNullException(nameof(serviceUrl));
             }
 
+            if (!S3ConfigurationValidator.ValidateServiceUrl(serviceUrl))
+            {
+                throw new ArgumentException(ErrorMessageConstants.ServiceUrlInvalidFormat, nameof(serviceUrl));
+            }
+
             if (string.IsNullOrWhiteSpace(outputTemplate))
             {
                 outputTemplate = DefaultOutputTemplate;
@@ -1007,6 +1022,11 @@ namespace Serilog
             if (string.IsNullOrWhiteSpace(serviceUrl))
             {
                 throw new ArgumentNullException(nameof(serviceUrl));
+            }
+
+            if(!S3ConfigurationValidator.ValidateServiceUrl(serviceUrl))
+            {
+                throw new ArgumentException(ErrorMessageConstants.ServiceUrlInvalidFormat, nameof(serviceUrl));
             }
 
             if (formatter is null)

--- a/src/Serilog.Sinks.AmazonS3/S3ConfigurationValidator.cs
+++ b/src/Serilog.Sinks.AmazonS3/S3ConfigurationValidator.cs
@@ -1,0 +1,19 @@
+﻿using Serilog.Sinks.AmazonS3;
+using System;
+
+namespace Serilog
+{
+    /// <summary>
+    /// Validators for configuration parameters. 
+    /// </summary>
+    internal static class S3ConfigurationValidator
+    {
+        /// <summary>
+        /// Validate the value provided for <see cref="AmazonS3Options.ServiceUrl"/> property.
+        /// </summary>
+        /// <param name="serviceUrl"></param>
+        /// <returns></returns>
+        internal static bool ValidateServiceUrl(string serviceUrl)
+            => Uri.TryCreate(serviceUrl, UriKind.Absolute, out _);
+    }
+}

--- a/src/Serilog.Sinks.AmazonS3/Sinks/AmazonS3/AmazonS3Options.cs
+++ b/src/Serilog.Sinks.AmazonS3/Sinks/AmazonS3/AmazonS3Options.cs
@@ -75,7 +75,7 @@ namespace Serilog.Sinks.AmazonS3
         /// <summary>
         /// Gets or sets the Amazon S3 service url.
         /// </summary>
-        public string ServiceUrl { get; set; } = "s3.amazonaws.com";
+        public string ServiceUrl { get; set; } = "https://s3.amazonaws.com";
 
         /// <summary>
         /// Gets or sets the path roller.


### PR DESCRIPTION
The AmazonS3Config class requires the protocol to be specified when using the ServiceUrl property.