### PR TITLE
Add appsettings example

### DIFF
--- a/HowToUse.md
+++ b/HowToUse.md
@@ -57,6 +57,26 @@ for (var x = 0; x < 200; x++)
 }
 ```
 
+## Configuring from appsettings.json files
+```json
+"Serilog": {
+    "MinimumLevel": {
+      "Default": "Information"
+    },
+    "WriteTo": [
+      {
+        "Name": "AmazonS3",
+        "Args": {
+          "path": "log.txt",
+          "bucketName": "mybucket-aws",
+          "rollingInterval": "Day",
+          "serviceUrl": "https://s3.eu-west-2.amazonaws.com"
+        }
+      }
+    ]
+  }
+```
+
 For more information regarding this use case, see [Issue number 10](https://github.com/serilog-contrib/Serilog.Sinks.AmazonS3/issues/10) and [Serilog formatting JSON](https://github.com/serilog/serilog/wiki/Formatting-Output#formatting-json).
 
 

--- a/README.md
+++ b/README.md
@@ -26,10 +26,12 @@ so thanks to all the [contributors](https://github.com/serilog/serilog-sinks-fil
 * NetStandard 2.0
 * NetStandard 2.1
 * NetCore 3.1
+* .NET 5
 
 ## Net Core and Net Framework latest and LTS versions
 * https://dotnet.microsoft.com/download/dotnet-framework
 * https://dotnet.microsoft.com/download/dotnet-core
+* https://dotnet.microsoft.com/download/dotnet
 
 ## Basic usage
 Check out the how to use file [here](https://github.com/serilog-contrib/Serilog.Sinks.AmazonS3/blob/master/HowToUse.md).


### PR DESCRIPTION
I had a couple of issues using this sink from appsettings, namely that the region endpoint can't be specified because it's a series of abstract class implementations (Serilog is clever enough to cast from strings to Enums, and handle some built-in types like ints/bools), but not to map to the RegionEndpoint classes.

It does work with the ServiceUrl specified instead (see separate PR for an issue I found with this), so thought it would be useful to single it out along with the endpoint gotcha.