### PR TITLE
added support for DisablePayloadSigning to disables the Amazon S3 SigV4 payload 

### DIFF
--- a/HowToUse.md
+++ b/HowToUse.md
@@ -70,7 +70,8 @@ for (var x = 0; x < 200; x++)
           "path": "log.txt",
           "bucketName": "mybucket-aws",
           "rollingInterval": "Day",
-          "serviceUrl": "https://s3.eu-west-2.amazonaws.com"
+          "serviceUrl": "https://s3.eu-west-2.amazonaws.com",
+          "disablePayloadSigning": "false"
         }
       }
     ]
@@ -127,6 +128,7 @@ The project can be found on [nuget](https://www.nuget.org/packages/Serilog.Sinks
 |batchingPeriod|The time to wait between checking for unemitted events. If there are any unemitted events, they will then be uploaded to S3 in a batch of maximum size `batchSizeLimit`.<br>Check: https://github.com/serilog/serilog-sinks-periodicbatching|`batchingPeriod = TimeSpan.FromSeconds(5)`|`TimeSpan.FromSeconds(2)`|
 |eagerlyEmitFirstEvent|A value indicating whether the first event should be emitted immediately or not.|`eagerlyEmitFirstEvent = false`|`true`|
 |queueSizeLimit|The queue size limit meaning the limit until the last not emitted events are discarded (Standard mechanims to stop queue overflows).|`queueSizeLimit = 2000`|`10000`|
+|disablePayloadSigning|Setting DisablePayloadSigning to true disables the Amazon S3 SigV4 payload signing data integrity check on upload request. This option is provided if you are using other cloud storage e.g. Cloudflare R2 and they support AWS S3 APIs but currently lack support for the Streaming SigV4 implementation used by AWSSDK.S3.|`disablePayloadSigning = true`| Default is `false`. Even a null value will also result in `false` setting |
 
 Hint: Only `outputTemplate` and `formatProvider` together or the `formatter` can be used.
 

--- a/src/Serilog.Sinks.AmazonS3.Tests/AmazonS3BasicTests.cs
+++ b/src/Serilog.Sinks.AmazonS3.Tests/AmazonS3BasicTests.cs
@@ -61,7 +61,8 @@ public class AmazonS3BasicTests
                 batchSizeLimit: null,
                 batchingPeriod: null,
                 eagerlyEmitFirstEvent: null,
-                queueSizeLimit: null)
+                queueSizeLimit: null,
+                disablePayloadSigning: null)
             .CreateLogger();
 
         for (var x = 0; x < 200; x++)
@@ -99,7 +100,8 @@ public class AmazonS3BasicTests
                 batchSizeLimit: null,
                 batchingPeriod: null,
                 eagerlyEmitFirstEvent: null,
-                queueSizeLimit: null)
+                queueSizeLimit: null,
+                disablePayloadSigning: null)
             .CreateLogger();
 
         for (var x = 0; x < 200; x++)
@@ -136,7 +138,8 @@ public class AmazonS3BasicTests
                 batchSizeLimit: null,
                 batchingPeriod: null,
                 eagerlyEmitFirstEvent: null,
-                queueSizeLimit: null)
+                queueSizeLimit: null,
+                disablePayloadSigning: null)
             .CreateLogger();
 
         for (var x = 0; x < 200; x++)

--- a/src/Serilog.Sinks.AmazonS3/LoggerConfigurationAmazonS3Extensions.cs
+++ b/src/Serilog.Sinks.AmazonS3/LoggerConfigurationAmazonS3Extensions.cs
@@ -89,6 +89,7 @@ public static class LoggerConfigurationAmazonS3Extensions
     /// <param name="batchingPeriod">The batching period.</param>
     /// <param name="eagerlyEmitFirstEvent">A value indicating whether the first event should be emitted immediately or not.</param>
     /// <param name="queueSizeLimit">The queue size limit.</param>
+    /// <param name="disablePayloadSigning">Setting DisablePayloadSigning to true disables the Amazon S3 SigV4 payload signing data integrity check on upload request.</param>
     /// <returns>The configuration object allowing method chaining.</returns>
     public static LoggerConfiguration AmazonS3(
         this LoggerSinkConfiguration sinkConfiguration,
@@ -108,7 +109,8 @@ public static class LoggerConfigurationAmazonS3Extensions
         int? batchSizeLimit = DefaultBatchSizeLimit,
         TimeSpan? batchingPeriod = null,
         bool? eagerlyEmitFirstEvent = DefaultEagerlyEmitFirstEvent,
-        int? queueSizeLimit = DefaultQueueSizeLimit)
+        int? queueSizeLimit = DefaultQueueSizeLimit,
+        bool? disablePayloadSigning = false)
     {
         if (sinkConfiguration is null)
         {
@@ -160,7 +162,8 @@ public static class LoggerConfigurationAmazonS3Extensions
             RollingInterval = rollingInterval,
             Encoding = encoding,
             FailureCallback = failureCallback,
-            BucketPath = bucketPath
+            BucketPath = bucketPath,
+            DisablePayloadSigning = disablePayloadSigning
         };
 
         var amazonS3Sink = new AmazonS3Sink(options);
@@ -216,6 +219,7 @@ public static class LoggerConfigurationAmazonS3Extensions
     /// <param name="batchingPeriod">The batching period.</param>
     /// <param name="eagerlyEmitFirstEvent">A value indicating whether the first event should be emitted immediately or not.</param>
     /// <param name="queueSizeLimit">The queue size limit.</param>
+    /// <param name="disablePayloadSigning">Setting DisablePayloadSigning to true disables the Amazon S3 SigV4 payload signing data integrity check on upload request.</param>
     /// <returns>The configuration object allowing method chaining.</returns>
     public static LoggerConfiguration AmazonS3(
         this LoggerSinkConfiguration sinkConfiguration,
@@ -234,7 +238,8 @@ public static class LoggerConfigurationAmazonS3Extensions
         int? batchSizeLimit = DefaultBatchSizeLimit,
         TimeSpan? batchingPeriod = null,
         bool? eagerlyEmitFirstEvent = DefaultEagerlyEmitFirstEvent,
-        int? queueSizeLimit = DefaultQueueSizeLimit)
+        int? queueSizeLimit = DefaultQueueSizeLimit,
+        bool? disablePayloadSigning = false)
     {
         if (sinkConfiguration is null)
         {
@@ -285,7 +290,8 @@ public static class LoggerConfigurationAmazonS3Extensions
             RollingInterval = rollingInterval,
             Encoding = encoding,
             FailureCallback = failureCallback,
-            BucketPath = bucketPath
+            BucketPath = bucketPath,
+            DisablePayloadSigning = disablePayloadSigning
         };
 
         var amazonS3Sink = new AmazonS3Sink(options);
@@ -351,6 +357,7 @@ public static class LoggerConfigurationAmazonS3Extensions
     /// <param name="batchingPeriod">The batching period.</param>
     /// <param name="eagerlyEmitFirstEvent">A value indicating whether the first event should be emitted immediately or not.</param>
     /// <param name="queueSizeLimit">The queue size limit.</param>
+    /// <param name="disablePayloadSigning">Setting DisablePayloadSigning to true disables the Amazon S3 SigV4 payload signing data integrity check on upload request.</param>
     /// <returns>The configuration object allowing method chaining.</returns>
     public static LoggerConfiguration AmazonS3(
         this LoggerSinkConfiguration sinkConfiguration,
@@ -368,7 +375,8 @@ public static class LoggerConfigurationAmazonS3Extensions
         int? batchSizeLimit = DefaultBatchSizeLimit,
         TimeSpan? batchingPeriod = null,
         bool? eagerlyEmitFirstEvent = DefaultEagerlyEmitFirstEvent,
-        int? queueSizeLimit = DefaultQueueSizeLimit)
+        int? queueSizeLimit = DefaultQueueSizeLimit,
+        bool? disablePayloadSigning = false)
     {
         if (sinkConfiguration is null)
         {
@@ -408,7 +416,8 @@ public static class LoggerConfigurationAmazonS3Extensions
             RollingInterval = rollingInterval,
             Encoding = encoding,
             FailureCallback = failureCallback,
-            BucketPath = bucketPath
+            BucketPath = bucketPath,
+            DisablePayloadSigning = disablePayloadSigning,
         };
 
         var amazonS3Sink = new AmazonS3Sink(options);
@@ -462,6 +471,7 @@ public static class LoggerConfigurationAmazonS3Extensions
     /// <param name="batchingPeriod">The batching period.</param>
     /// <param name="eagerlyEmitFirstEvent">A value indicating whether the first event should be emitted immediately or not.</param>
     /// <param name="queueSizeLimit">The queue size limit.</param>
+    /// <param name="disablePayloadSigning">Setting DisablePayloadSigning to true disables the Amazon S3 SigV4 payload signing data integrity check on upload request.</param>
     /// <returns>The configuration object allowing method chaining.</returns>
     public static LoggerConfiguration AmazonS3(
         this LoggerSinkConfiguration sinkConfiguration,
@@ -478,7 +488,8 @@ public static class LoggerConfigurationAmazonS3Extensions
         int? batchSizeLimit = DefaultBatchSizeLimit,
         TimeSpan? batchingPeriod = null,
         bool? eagerlyEmitFirstEvent = DefaultEagerlyEmitFirstEvent,
-        int? queueSizeLimit = DefaultQueueSizeLimit)
+        int? queueSizeLimit = DefaultQueueSizeLimit,
+        bool? disablePayloadSigning = false)
     {
         if (sinkConfiguration is null)
         {
@@ -517,8 +528,9 @@ public static class LoggerConfigurationAmazonS3Extensions
             RollingInterval = rollingInterval,
             Encoding = encoding,
             FailureCallback = failureCallback,
-            BucketPath = bucketPath
-        };
+            BucketPath = bucketPath,
+			DisablePayloadSigning = disablePayloadSigning
+		};
 
         var amazonS3Sink = new AmazonS3Sink(options);
 
@@ -578,6 +590,7 @@ public static class LoggerConfigurationAmazonS3Extensions
     /// <param name="batchingPeriod">The batching period.</param>
     /// <param name="eagerlyEmitFirstEvent">A value indicating whether the first event should be emitted immediately or not.</param>
     /// <param name="queueSizeLimit">The queue size limit.</param>
+    /// <param name="disablePayloadSigning">Setting DisablePayloadSigning to true disables the Amazon S3 SigV4 payload signing data integrity check on upload request.</param>
     /// <returns>The configuration object allowing method chaining.</returns>
     public static LoggerConfiguration AmazonS3(
         this LoggerSinkConfiguration sinkConfiguration,
@@ -597,7 +610,8 @@ public static class LoggerConfigurationAmazonS3Extensions
         int? batchSizeLimit = DefaultBatchSizeLimit,
         TimeSpan? batchingPeriod = null,
         bool? eagerlyEmitFirstEvent = DefaultEagerlyEmitFirstEvent,
-        int? queueSizeLimit = DefaultQueueSizeLimit)
+        int? queueSizeLimit = DefaultQueueSizeLimit,
+        bool? disablePayloadSigning = false)
     {
         if (sinkConfiguration is null)
         {
@@ -655,7 +669,8 @@ public static class LoggerConfigurationAmazonS3Extensions
             Encoding = encoding,
             FailureCallback = failureCallback,
             BucketPath = bucketPath,
-            Endpoint = null
+            Endpoint = null,
+            DisablePayloadSigning = disablePayloadSigning
         };
 
         var amazonS3Sink = new AmazonS3Sink(options);
@@ -711,6 +726,7 @@ public static class LoggerConfigurationAmazonS3Extensions
     /// <param name="batchingPeriod">The batching period.</param>
     /// <param name="eagerlyEmitFirstEvent">A value indicating whether the first event should be emitted immediately or not.</param>
     /// <param name="queueSizeLimit">The queue size limit.</param>
+    /// <param name="disablePayloadSigning">Setting DisablePayloadSigning to true disables the Amazon S3 SigV4 payload signing data integrity check on upload request.</param>
     /// <returns>The configuration object allowing method chaining.</returns>
     public static LoggerConfiguration AmazonS3(
         this LoggerSinkConfiguration sinkConfiguration,
@@ -729,7 +745,8 @@ public static class LoggerConfigurationAmazonS3Extensions
         int? batchSizeLimit = DefaultBatchSizeLimit,
         TimeSpan? batchingPeriod = null,
         bool? eagerlyEmitFirstEvent = DefaultEagerlyEmitFirstEvent,
-        int? queueSizeLimit = DefaultQueueSizeLimit)
+        int? queueSizeLimit = DefaultQueueSizeLimit,
+        bool? disablePayloadSigning = false)
     {
         if (sinkConfiguration is null)
         {
@@ -786,7 +803,8 @@ public static class LoggerConfigurationAmazonS3Extensions
             Encoding = encoding,
             FailureCallback = failureCallback,
             BucketPath = bucketPath,
-            Endpoint = null
+            Endpoint = null,
+            DisablePayloadSigning = disablePayloadSigning
         };
 
         var amazonS3Sink = new AmazonS3Sink(options);
@@ -852,6 +870,7 @@ public static class LoggerConfigurationAmazonS3Extensions
     /// <param name="batchingPeriod">The batching period.</param>
     /// <param name="eagerlyEmitFirstEvent">A value indicating whether the first event should be emitted immediately or not.</param>
     /// <param name="queueSizeLimit">The queue size limit.</param>
+    /// <param name="disablePayloadSigning">Setting DisablePayloadSigning to true disables the Amazon S3 SigV4 payload signing data integrity check on upload request.</param>
     /// <returns>The configuration object allowing method chaining.</returns>
     public static LoggerConfiguration AmazonS3(
         this LoggerSinkConfiguration sinkConfiguration,
@@ -869,7 +888,8 @@ public static class LoggerConfigurationAmazonS3Extensions
         int? batchSizeLimit = DefaultBatchSizeLimit,
         TimeSpan? batchingPeriod = null,
         bool? eagerlyEmitFirstEvent = DefaultEagerlyEmitFirstEvent,
-        int? queueSizeLimit = DefaultQueueSizeLimit)
+        int? queueSizeLimit = DefaultQueueSizeLimit,
+        bool? disablePayloadSigning = false)
     {
         if (sinkConfiguration is null)
         {
@@ -915,7 +935,8 @@ public static class LoggerConfigurationAmazonS3Extensions
             Encoding = encoding,
             FailureCallback = failureCallback,
             BucketPath = bucketPath,
-            Endpoint = null
+            Endpoint = null,
+            DisablePayloadSigning = disablePayloadSigning
         };
 
         var amazonS3Sink = new AmazonS3Sink(options);
@@ -969,6 +990,7 @@ public static class LoggerConfigurationAmazonS3Extensions
     /// <param name="batchingPeriod">The batching period.</param>
     /// <param name="eagerlyEmitFirstEvent">A value indicating whether the first event should be emitted immediately or not.</param>
     /// <param name="queueSizeLimit">The queue size limit.</param>
+    /// <param name="disablePayloadSigning">Setting DisablePayloadSigning to true disables the Amazon S3 SigV4 payload signing data integrity check on upload request.</param>
     /// <returns>The configuration object allowing method chaining.</returns>
     public static LoggerConfiguration AmazonS3(
         this LoggerSinkConfiguration sinkConfiguration,
@@ -985,7 +1007,8 @@ public static class LoggerConfigurationAmazonS3Extensions
         int? batchSizeLimit = DefaultBatchSizeLimit,
         TimeSpan? batchingPeriod = null,
         bool? eagerlyEmitFirstEvent = DefaultEagerlyEmitFirstEvent,
-        int? queueSizeLimit = DefaultQueueSizeLimit)
+        int? queueSizeLimit = DefaultQueueSizeLimit,
+        bool? disablePayloadSigning = false)
     {
         if (sinkConfiguration is null)
         {
@@ -1030,7 +1053,8 @@ public static class LoggerConfigurationAmazonS3Extensions
             Encoding = encoding,
             FailureCallback = failureCallback,
             BucketPath = bucketPath,
-            Endpoint = null
+            Endpoint = null,
+            DisablePayloadSigning = disablePayloadSigning
         };
 
         var amazonS3Sink = new AmazonS3Sink(options);
@@ -1096,6 +1120,7 @@ public static class LoggerConfigurationAmazonS3Extensions
     /// <param name="batchingPeriod">The batching period.</param>
     /// <param name="eagerlyEmitFirstEvent">A value indicating whether the first event should be emitted immediately or not.</param>
     /// <param name="queueSizeLimit">The queue size limit.</param>
+    /// <param name="disablePayloadSigning">Setting DisablePayloadSigning to true disables the Amazon S3 SigV4 payload signing data integrity check on upload request.</param>
     /// <returns>The configuration object allowing method chaining.</returns>
     public static LoggerConfiguration AmazonS3(
         this LoggerSinkConfiguration sinkConfiguration,
@@ -1113,7 +1138,8 @@ public static class LoggerConfigurationAmazonS3Extensions
         int? batchSizeLimit = DefaultBatchSizeLimit,
         TimeSpan? batchingPeriod = null,
         bool? eagerlyEmitFirstEvent = DefaultEagerlyEmitFirstEvent,
-        int? queueSizeLimit = DefaultQueueSizeLimit)
+        int? queueSizeLimit = DefaultQueueSizeLimit,
+        bool? disablePayloadSigning = false)
     {
         if (sinkConfiguration is null)
         {
@@ -1153,7 +1179,8 @@ public static class LoggerConfigurationAmazonS3Extensions
             RollingInterval = rollingInterval,
             Encoding = encoding,
             FailureCallback = failureCallback,
-            BucketPath = bucketPath
+            BucketPath = bucketPath,
+            DisablePayloadSigning = disablePayloadSigning
         };
 
         var amazonS3Sink = new AmazonS3Sink(options);
@@ -1207,6 +1234,7 @@ public static class LoggerConfigurationAmazonS3Extensions
     /// <param name="batchingPeriod">The batching period.</param>
     /// <param name="eagerlyEmitFirstEvent">A value indicating whether the first event should be emitted immediately or not.</param>
     /// <param name="queueSizeLimit">The queue size limit.</param>
+    /// <param name="disablePayloadSigning">Setting DisablePayloadSigning to true disables the Amazon S3 SigV4 payload signing data integrity check on upload request.</param>
     /// <returns>The configuration object allowing method chaining.</returns>
     public static LoggerConfiguration AmazonS3(
         this LoggerSinkConfiguration sinkConfiguration,
@@ -1223,7 +1251,8 @@ public static class LoggerConfigurationAmazonS3Extensions
         int? batchSizeLimit = DefaultBatchSizeLimit,
         TimeSpan? batchingPeriod = null,
         bool? eagerlyEmitFirstEvent = DefaultEagerlyEmitFirstEvent,
-        int? queueSizeLimit = DefaultQueueSizeLimit)
+        int? queueSizeLimit = DefaultQueueSizeLimit,
+        bool? disablePayloadSigning = false)
     {
         if (sinkConfiguration is null)
         {
@@ -1262,7 +1291,8 @@ public static class LoggerConfigurationAmazonS3Extensions
             RollingInterval = rollingInterval,
             Encoding = encoding,
             FailureCallback = failureCallback,
-            BucketPath = bucketPath
+            BucketPath = bucketPath,
+            DisablePayloadSigning = disablePayloadSigning
         };
 
         var amazonS3Sink = new AmazonS3Sink(options);

--- a/src/Serilog.Sinks.AmazonS3/Sinks/AmazonS3/AmazonS3Options.cs
+++ b/src/Serilog.Sinks.AmazonS3/Sinks/AmazonS3/AmazonS3Options.cs
@@ -98,4 +98,9 @@ public class AmazonS3Options
     /// Gets or sets the current file sequence number. Internally used only, not to be set by the options.
     /// </summary>
     public int? CurrentFileSequence { get; set; }
+
+    /// <summary>
+    /// Gets or sets the S3 PutObjectRequest Property DisablePayloadSigning
+    /// </summary>
+    public bool? DisablePayloadSigning { get; set; } = false;
 }

--- a/src/Serilog.Sinks.AmazonS3/Sinks/AmazonS3/AmazonS3Sink.cs
+++ b/src/Serilog.Sinks.AmazonS3/Sinks/AmazonS3/AmazonS3Sink.cs
@@ -49,6 +49,7 @@ public class AmazonS3Sink : IBatchedLogEventSink
         this.amazonS3Options.RollingInterval = amazonS3Options.RollingInterval;
         this.amazonS3Options.OutputTemplate = amazonS3Options.OutputTemplate;
         this.amazonS3Options.FormatProvider = amazonS3Options.FormatProvider;
+        this.amazonS3Options.DisablePayloadSigning = amazonS3Options.DisablePayloadSigning;
     }
 
     /// <summary>Emit a batch of log events, running asynchronously.</summary>
@@ -282,7 +283,8 @@ public class AmazonS3Sink : IBatchedLogEventSink
             {
                 BucketName = this.amazonS3Options.BucketName,
                 Key = key,
-                InputStream = fs
+                InputStream = fs,
+                DisablePayloadSigning = this.amazonS3Options.DisablePayloadSigning
             };
 
             return await client.PutObjectAsync(putRequest);


### PR DESCRIPTION
added support for DisablePayloadSigning to disables the Amazon S3 SigV4 payload signing data integrity check on upload request, since cloudflare R2 does not work with SigV4 yet.

#55 