### PR TITLE
Turned off sequence number from rolling file for new time sequence files

### DIFF
--- a/src/Serilog.Sinks.AmazonS3/Sinks/AmazonS3/AmazonS3Sink.cs
+++ b/src/Serilog.Sinks.AmazonS3/Sinks/AmazonS3/AmazonS3Sink.cs
@@ -93,7 +93,7 @@ public class AmazonS3Sink : IBatchedLogEventSink
     /// <returns>The <see cref="FileInformation"/>.</returns>
     private FileInformation OpenFile()
     {
-        var fileName = this.AlignCurrentFileTo(DateTime.Now, true);
+        var fileName = this.AlignCurrentFileTo(DateTime.Now, false);
 
         var directory = Path.GetDirectoryName(this.amazonS3Options.Path);
 


### PR DESCRIPTION
Turned off sequence number from rolling files in new files. There is no implementation for checking file size
and roll sequence number when log file exceeds limit size, this option is turned off as it does not work correctly. 
Change will only start work from new rolling time interval, e. g. if RollingInterval is set to Day, and in bucket already exist logs for today and contains sequence number in filename, this fix will work from next day, and will create file without sequence number.
fixes #52 
